### PR TITLE
ServiceView - FormView that handles mechanics of calling a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,14 @@ You can use this service object anywhere. Here's an example of it being used in 
 ```python
 # your_app/views.py
 
+from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect, render
+from service_objects import views
 
 from .forms import BookingForm
 from .services import CreateBookingService
 
+# Function View
 def create_booking_view(request):
     form = BookingForm()
 
@@ -99,6 +102,15 @@ def create_booking_view(request):
                 form.add_error(None, f'Sorry. Something went wrong: {e}')
 
     return render(request, 'booking/create_booking.html', {'form': form})
+
+
+# Class Based View
+class CreateBookingView(views.ServiceView):
+    form_class = BookingForm
+    service_class = CreateBookingService
+    template_name = 'booking/create_booking.html'
+    success_url = reverse_lazy('booking:success')
+
 ```
 
 An example of testing CreateBookingService

--- a/service_objects/views.py
+++ b/service_objects/views.py
@@ -1,0 +1,38 @@
+from django.views.generic import FormView
+
+
+class ServiceView(FormView):
+    service_class = None
+
+    def get_form_class(self):
+        return self.form_class if self.form_class else self.service_class
+
+    def get_service_class(self):
+        return self.service_class
+
+    def get_service_kwargs(self):
+        return {}
+
+    def get_service_input(self, form):
+        return form.cleaned_data
+
+    def get_service_files(self):
+        rv = None
+        if self.request.method in ('POST', 'PUT'):
+            rv = self.request.FILES
+
+        return rv
+
+    def form_valid(self, form):
+        try:
+            cls = self.get_service_class()
+            cls.execute(
+                self.get_service_input(form),
+                self.get_service_files(),
+                **self.get_service_kwargs()
+            )
+            return super(ServiceView, self).form_valid(form)
+
+        except Exception as e:
+            form.add_error(None, str(e))
+            return self.form_invalid(form)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,122 @@
+try:
+    from unittest.mock import MagicMock, PropertyMock, patch
+except ImportError:
+    from mock import MagicMock, PropertyMock, patch
+
+from unittest import TestCase
+
+from service_objects.views import ServiceView
+
+
+MockService = MagicMock()
+
+
+MockForm = MagicMock()
+
+
+class MockView(ServiceView):
+    form_class = MockForm
+    service_class = MockService
+
+
+class FooView(ServiceView):
+    service_class = MockService
+
+
+ExceptionService = MagicMock()
+ExceptionService.execute = MagicMock(side_effect=Exception('Testing'))
+
+
+class ExceptionView(ServiceView):
+    service_class = ExceptionService
+
+
+class ViewTest(TestCase):
+
+    def build_request(self, method_return_value, FILES_return_value):
+        request = MagicMock()
+        method = PropertyMock(return_value=method_return_value)
+        type(request).method = method
+        FILES = PropertyMock(return_value=FILES_return_value)
+        type(request).FILES = FILES
+
+        return request, method, FILES
+
+    def test_get_form_class(self):
+        view = MockView()
+        rv = view.get_form_class()
+
+        self.assertEqual(MockForm, rv)
+
+    def test_get_form_class_override(self):
+        view = FooView()
+        rv = view.get_form_class()
+
+        self.assertEqual(MockService, rv)
+
+    def test_get_service_class(self):
+        view = MockView()
+        rv = view.get_service_class()
+
+        self.assertEqual(MockService, rv)
+
+    def test_get_service_input(self):
+        form = MagicMock()
+        cleaned_data = PropertyMock(return_value={})
+        type(form).cleaned_data = cleaned_data
+
+        view = MockView()
+        rv = view.get_service_input(form)
+
+        cleaned_data.assert_called_once_with()
+        self.assertEqual({}, rv)
+
+    def test_get_service_files_none(self):
+        request, method, FILES = self.build_request('GET', {})
+
+        view = MockView()
+        view.request = request
+        rv = view.get_service_files()
+
+        self.assertEqual(None, rv)
+        method.assert_called_once_with()
+        FILES.assert_not_called()
+
+    def test_get_service_files_data(self):
+        files = {'file1': 'filedata'}
+        request, method, FILES = self.build_request('POST', files)
+
+        view = MockView()
+        view.request = request
+        rv = view.get_service_files()
+
+        self.assertEqual(files, rv)
+        method.assert_called_once_with()
+        FILES.assert_called_once_with()
+
+    @patch('django.views.generic.FormView.form_valid')
+    @patch('django.views.generic.FormView.form_invalid')
+    def test_form_valid_exception(self, form_invalid, form_valid):
+        request, _, _ = self.build_request('GET', {})
+        form = MagicMock()
+
+        view = ExceptionView()
+        view.request = request
+        view.form_valid(form)
+
+        form_valid.assert_not_called()
+        form_invalid.assert_called_once_with(form)
+        form.add_error.assert_called_once_with(None, 'Testing')
+
+    @patch('django.views.generic.FormView.form_valid')
+    @patch('django.views.generic.FormView.form_invalid')
+    def test_form_valid_good(self, form_invalid, form_valid):
+        request, _, _ = self.build_request('GET', {})
+        form = MagicMock()
+
+        view = MockView()
+        view.request = request
+        view.form_valid(form)
+
+        form_valid.assert_called_once_with(form)
+        form_invalid.assert_not_called()


### PR DESCRIPTION
Follows the usual CBV pattern of most data coming from method calls that
can be overridden as necessary.  `form_valid` mimics the FBV example in
the README.

Possibly controversial is `get_form_class` that will use the Service as
the Form if no form_class is given.  My homegrown similar style uses a
Django Form as both the UI and business rules (via a execute() instance
method) which is why I coded ServiceView that way.  But for this
library, I could go either way.