### PR TITLE
Add database transaction feature flag

### DIFF
--- a/service_objects/services.py
+++ b/service_objects/services.py
@@ -59,9 +59,10 @@ class Service(forms.Form):
         Returns the context for :meth:`process`
         :return:
         """
-        yield
         if self.db_transaction:
-            return transaction.atomic()
+            yield transaction.atomic()
+        else:
+            yield
 
 
 class ModelService(with_metaclass(models.ModelFormMetaclass, Service)):


### PR DESCRIPTION
Adds a feature flag to toggle `process` being wrapped in a database transaction. Defaults to `True`, ensuring backwards compatibility.

Includes basic test. Doesn't include any changes to documentation.

Resolves #8.