### PR TITLE
ModelField implementation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,9 @@
-[coverage:run]
+[run]
 	branch = True
 	include =
 		*/service_objects/*
 
-[coverage:report]
+[report]
 	show_missing = True
 	precision = 2
 	sort = Name

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ test: flake
 	python runtests.py
 
 coverage: flake
-	coverage run --source='service_objects' runtests.py
+	coverage run runtests.py
 	coverage report

--- a/service_objects/fields.py
+++ b/service_objects/fields.py
@@ -120,6 +120,8 @@ class MultipleModelField(ModelField):
     A multiple model version of :class:`ModelField`, will check each passed
     in object to match the specified :class:`Model`.
 
+    Will always return data as a list even if only a single object is passed in.
+
         :param model_class: Django :class:`Model` or dotted string of :
             class:`Model` name
         :param allow_unsaved: Whether the object is required to be saved to

--- a/service_objects/fields.py
+++ b/service_objects/fields.py
@@ -120,8 +120,6 @@ class MultipleModelField(ModelField):
     A multiple model version of :class:`ModelField`, will check each passed
     in object to match the specified :class:`Model`.
 
-    Will always return data as a list even if only a single object is passed in.
-
         :param model_class: Django :class:`Model` or dotted string of :
             class:`Model` name
         :param allow_unsaved: Whether the object is required to be saved to

--- a/service_objects/fields.py
+++ b/service_objects/fields.py
@@ -128,9 +128,11 @@ class MultipleModelField(ModelField):
             the database
 
     """
+    error_non_list = _("Object is not iterable")
+
     def clean(self, values):
         if not isinstance(values, list):
-            values = [values]
+            raise ValidationError(self.error_non_list)
 
         for value in values:
             self.check_type(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[coverage:run]
+	branch = True
+	include =
+		*/service_objects/*
+
+[coverage:report]
+	show_missing = True
+	precision = 2
+	sort = Name

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TestsConfig(AppConfig):
+    name = 'Tests'
+    label = 'tests'

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class FooForm(forms.Form):
+    name = forms.CharField(max_length=5)

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,3 +4,10 @@ from django.db import models
 class FooModel(models.Model):
     one = models.CharField(max_length=1)
 
+
+class BarModel(models.Model):
+    one = models.CharField(max_length=1)
+
+
+class NonModel(object):
+    pass

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,6 @@
+from django.db import models
+
+
+class FooModel(models.Model):
+    one = models.CharField(max_length=1)
+

--- a/tests/services.py
+++ b/tests/services.py
@@ -1,0 +1,14 @@
+from django import forms
+from service_objects.services import Service
+
+
+class FooService(Service):
+    bar = forms.CharField(required=True)
+
+
+class MockService(Service):
+    bar = forms.CharField(required=True)
+
+
+class NoDbTransactionService(Service):
+    db_transaction = False

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -4,10 +4,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 
 from service_objects.fields import MultipleFormField
-
-
-class FooForm(forms.Form):
-    name = forms.CharField(max_length=5)
+from tests.forms import FooForm
 
 
 class MultipleFormFieldTest(TestCase):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -134,16 +134,13 @@ class MultipleModelFieldTest(TestCase):
         with self.assertRaisesRegexp(ValidationError, "[Uu]nsaved"):
             cleaned_data = model_field.clean(objects)
 
-
     def test_multiple_non_list(self):
         model_field = MultipleModelField(FooModel)
         obj = FooModel(one='a')
         obj.pk = 1
 
-        cleaned_data = model_field.clean(obj)
-
-        self.assertTrue(isinstance(cleaned_data, list))
-        self.assertEqual(obj, cleaned_data[0])
+        with self.assertRaisesRegexp(ValidationError, "[Ii]terable"):
+            cleaned_data = model_field.clean(obj)
 
     def test_multiple_valid(self):
         model_field = MultipleModelField(FooModel)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,25 +11,8 @@ from django.db import models
 
 from service_objects.errors import InvalidInputsError
 from service_objects.services import Service, ModelService
-
-
-class FooModel(models.Model):
-    one = models.CharField(max_length=1)
-
-    class Meta:
-        app_label = 'tests'
-
-
-class FooService(Service):
-    bar = forms.CharField(required=True)
-
-
-class MockService(Service):
-    bar = forms.CharField(required=True)
-
-
-class NoDbTransactionService(Service):
-    db_transaction = False
+from tests.models import FooModel
+from tests.services import FooService, MockService, NoDbTransactionService
 
 
 MockService.process = Mock()


### PR DESCRIPTION
- model_class: can be a Django Model reference or a dotted string
- allow_unsaved: whether object needs to be persisted to database before being used.  Currently defaults to `False` but I have no opinion either way

I took a look at Django's ForeignModel and how it handles class reference as well as class name in a string, mimic'd what it does.  Otherwise, pretty simple.

Closes #15 