### PR TITLE
Suggestion: Use initials as defaults

### DIFF
--- a/service_objects/services.py
+++ b/service_objects/services.py
@@ -14,6 +14,13 @@ class ServiceMetaclass(abc.ABCMeta, DeclarativeFieldsMetaclass):
     pass
 
 
+def get_initial_for_field_fill(klass, field, field_name):
+            value = klass.initial.get(field_name, field.initial)
+            if callable(value):
+                value = value()
+            return value
+
+
 @six.add_metaclass(ServiceMetaclass)
 class Service(forms.Form):
     """
@@ -52,6 +59,16 @@ class Service(forms.Form):
         """
         if not self.is_valid():
             raise InvalidInputsError(self.errors, self.non_field_errors())
+
+    def get_initial_for_field(self, field, field_name):
+        """
+        To make it work for django 1.8
+        Get_initial_for_field_fill comes from django 2.0 codebase
+        """
+        try:
+            return super(Service, self).get_initial_for_field(field, field_name)
+        except AttributeError:
+            return get_initial_for_field_fill(self, field, field_name)
 
     def full_clean(self):
         """

--- a/service_objects/services.py
+++ b/service_objects/services.py
@@ -53,6 +53,16 @@ class Service(forms.Form):
         if not self.is_valid():
             raise InvalidInputsError(self.errors, self.non_field_errors())
 
+    def full_clean(self):
+        """
+        Called before BaseForm.full_clean, use initial
+        value as a fallback when no data is given.
+        """
+        for name, field in self.fields.items():
+            if name not in self.data or not self.data[name]:
+                self.data[name] = self.get_initial_for_field(field, name)
+        super(Service, self).full_clean()
+
     @abc.abstractmethod
     def process(self):
         """

--- a/service_objects/services.py
+++ b/service_objects/services.py
@@ -29,6 +29,7 @@ class Service(forms.Form):
     the Service's defined fields before calling main functionality.
     """
 
+    use_initials_as_default = False
     db_transaction = True
     using = DEFAULT_DB_ALIAS
 
@@ -75,9 +76,10 @@ class Service(forms.Form):
         Called before BaseForm.full_clean, use initial
         value as a fallback when no data is given.
         """
-        for name, field in self.fields.items():
-            if name not in self.data or not self.data[name]:
-                self.data[name] = self.get_initial_for_field(field, name)
+        if self.use_initials_as_default:
+            for name, field in self.fields.items():
+                if name not in self.data or not self.data[name]:
+                    self.data[name] = self.get_initial_for_field(field, name)
         super(Service, self).full_clean()
 
     @abc.abstractmethod

--- a/tests/services.py
+++ b/tests/services.py
@@ -19,3 +19,21 @@ class NoDbTransactionService(Service):
 
     def process(self):
         pass
+
+
+class InitialDataService(Service):
+    bar = forms.CharField(required=False, initial='initial text')
+    foo = forms.CharField(required=False)
+
+    def clean_bar(self):
+        return self.cleaned_data['bar']
+
+    def process(self):
+        return self.cleaned_data
+
+
+class InvalidInitialDataService(Service):
+    bar = forms.IntegerField(required=False, initial='foo')
+
+    def process(self):
+        return self.cleaned_data

--- a/tests/services.py
+++ b/tests/services.py
@@ -21,9 +21,14 @@ class NoDbTransactionService(Service):
         pass
 
 
+def get_initial_data():
+    return 'get_initial_data'
+
+
 class InitialDataService(Service):
     bar = forms.CharField(required=False, initial='initial text')
     foo = forms.CharField(required=False)
+    foobar = forms.CharField(required=False, initial=get_initial_data)
 
     def clean_bar(self):
         return self.cleaned_data['bar']

--- a/tests/services.py
+++ b/tests/services.py
@@ -29,6 +29,7 @@ class InitialDataService(Service):
     bar = forms.CharField(required=False, initial='initial text')
     foo = forms.CharField(required=False)
     foobar = forms.CharField(required=False, initial=get_initial_data)
+    use_initials_as_default = True
 
     def clean_bar(self):
         return self.cleaned_data['bar']
@@ -39,6 +40,7 @@ class InitialDataService(Service):
 
 class InvalidInitialDataService(Service):
     bar = forms.IntegerField(required=False, initial='foo')
+    use_initials_as_default = True
 
     def process(self):
         return self.cleaned_data

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,7 +11,8 @@ from django import forms
 from service_objects.errors import InvalidInputsError
 from service_objects.services import ModelService
 from tests.models import FooModel
-from tests.services import FooService, MockService, NoDbTransactionService
+from tests.services import FooService, MockService, \
+    NoDbTransactionService, InitialDataService, InvalidInitialDataService
 
 MockService.process = Mock()
 NoDbTransactionService.process = Mock()
@@ -50,6 +51,17 @@ class ServiceTest(TestCase):
 
         MockService.execute({'bar': 'Hello'})
         assert mock_transaction.atomic.return_value.__enter__.called
+
+    def test_initial_data_return(self):
+        data = InitialDataService.execute({})
+        self.assertEqual('initial text', data['bar'])
+        self.assertEqual('', data['foo'])
+        data = InitialDataService.execute({'bar': 'not initial text'})
+        self.assertEqual('not initial text', data['bar'])
+
+    def test_invalid_initial_data(self):
+        with self.assertRaises(InvalidInputsError):
+            InvalidInitialDataService.execute({})
 
 
 class ModelServiceTest(TestCase):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,7 +9,7 @@ import six
 from django import forms
 
 from service_objects.errors import InvalidInputsError
-from service_objects.services import ModelService
+from service_objects.services import ModelService, get_initial_for_field_fill
 from tests.models import FooModel
 from tests.services import FooService, MockService, \
     NoDbTransactionService, InitialDataService, InvalidInitialDataService
@@ -62,6 +62,13 @@ class ServiceTest(TestCase):
     def test_invalid_initial_data(self):
         with self.assertRaises(InvalidInputsError):
             InvalidInitialDataService.execute({})
+
+    def test_get_initial_for_field(self):
+        form = InitialDataService()
+        initial_data = get_initial_for_field_fill(form, form.fields['bar'], 'bar')
+        self.assertEqual('initial text', initial_data)
+        initial_data = get_initial_for_field_fill(form, form.fields['foobar'], 'foobar')
+        self.assertEqual('get_initial_data', initial_data)
 
 
 class ModelServiceTest(TestCase):


### PR DESCRIPTION
Django forms comments the following: 
`initial -- A value to use in this Field's initial display. This is *not* used as a fallback if data isn't given.`

But for service objects it would be useful to be able to create a fallback if data isn't given. So I added a small function to Service which in my experience so far has been working very nicely. It simply uses the value of initial to create default values for empty input parameters. Of course these input parameters can only be empty if `Field(required=False)`.

Before:
```
class GetTestService(Service):
    test = forms.CharField(required=False)
    model_instance = ModelField(model_class=SomeModel, required=False)

    def process(self):
        test = self.cleaned_data['test'] or 'foo'
        model_instance = self.cleaned_data['model_instance'] or get_model()
        return test, model_instance
```
After:
```
class GetTestService(Service):
    use_initials_as_default = True
    test = forms.CharField(required=False, initial="foo")
    model_instance = ModelField(model_class=SomeModel, required=False, initial=get_model)

    def process(self):
        return self.cleaned_data['test'], self.cleaned_data['model_instance']
```
So we can leave Service.execute input empty and it will take the initial fields as default. `GetTestService.execute({})` will return `('foo', <SomeModel: bar>)` and `GetTestService.execute({'test': 'not_inital'})` will return `('not_inital', <SomeModel: bar>)`.

Let me know what you think ;)