### PR TITLE
Fix type hint errors with kwargs for python3.

### DIFF
--- a/service_objects/services.py
+++ b/service_objects/services.py
@@ -71,7 +71,7 @@ class Service(forms.Form):
         :param dictionary files: usually request's FILES dictionary or
             None.
 
-        :param dictionary kwargs: any additional parameters Service may
+        :param dictionary **kwargs: any additional parameters Service may
             need, can be an empty dictionary
         """
         instance = cls(inputs, files, **kwargs)


### PR DESCRIPTION
Change needed to suppress type errors in python3 function annotation.