### PR TITLE
Removed dependancy on django utils six

### DIFF
--- a/service_objects/services.py
+++ b/service_objects/services.py
@@ -5,7 +5,7 @@ from django import forms
 from django.db import transaction, DEFAULT_DB_ALIAS
 from django.forms.forms import DeclarativeFieldsMetaclass
 from django.forms.models import ModelFormMetaclass
-from django.utils import six
+import six
 
 from .errors import InvalidInputsError
 


### PR DESCRIPTION
Django 3.0 deprecates the use of six from `django.utils`, as can be seen [here](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis). This PR makes use of the six package which is already used.