### PR TITLE
Added support for DictField / ListField

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 **Features and Improvements**
 
 * Added support for DictField - peterfarrell
+* Added support for ListField - peterfarrell
 
 ## 0.6.0 (2020-01-03)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features and Improvements**
+
+* Added support for DictField - peterfarrell
+
 ## 0.6.0 (2020-01-03)
 
 **Features and Improvements**

--- a/service_objects/fields.py
+++ b/service_objects/fields.py
@@ -242,3 +242,37 @@ class DictField(forms.Field):
             raise ValidationError(self.error_type)
 
         return value
+
+
+class ListField(forms.Field):
+    """
+    A field for :class:`Service` that accepts a list:
+
+        class EmailWelcomeMessage(Service):
+            emails = ListField()
+
+            process(self):
+                emails = self.cleaned_data['emails']
+
+        EmailWelcomeMessage.execute({
+            'emails': ['blue@test.com', 'red@test.com']
+        })
+
+
+    """
+    error_required = _("Input is required. Expected list but got %(value)r.")
+    error_type = _("Input needs to be of type list.")
+
+    def clean(self, value):
+        if not value and value is not False:
+            if self.required:
+                raise ValidationError(self.error_required % {
+                    'value': value
+                })
+            else:
+                return {}
+
+        if not isinstance(value, list):
+            raise ValidationError(self.error_type)
+
+        return value

--- a/service_objects/fields.py
+++ b/service_objects/fields.py
@@ -226,8 +226,8 @@ class DictField(forms.Field):
 
 
     """
-    error_required = "Input is required. Expected dictionary but got %(value)r."
-    error_type = "Input needs to be of type dict."
+    error_required = _("Input is required. Expected dict but got %(value)r.")
+    error_type = _("Input needs to be of type dict.")
 
     def clean(self, value):
         if not value and value is not False:

--- a/service_objects/fields.py
+++ b/service_objects/fields.py
@@ -208,3 +208,37 @@ class MultipleModelField(ModelField):
             self.check_type(value)
             self.check_unsaved(value)
         return values
+
+
+class DictField(forms.Field):
+    """
+    A field for :class:`Service` that accepts a dictionary:
+
+        class PDFGenerate(Service):
+            context = DictField()
+
+            process(self):
+                context = self.cleaned_data['context']
+
+        PDFGenerate.execute({
+            'context': {'a': 1, 'b': 2}
+        })
+
+
+    """
+    error_required = "Input is required. Expected dictionary but got %(value)r."
+    error_type = "Input needs to be of type dict."
+
+    def clean(self, value):
+        if not value and value is not False:
+            if self.required:
+                raise ValidationError(self.error_required % {
+                    'value': value
+                })
+            else:
+                return {}
+
+        if not isinstance(value, dict):
+            raise ValidationError(self.error_type)
+
+        return value

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from django.core.exceptions import ValidationError
 
-from service_objects.fields import MultipleFormField, ModelField, MultipleModelField
+from service_objects.fields import MultipleFormField, ModelField, MultipleModelField, DictField
 from tests.forms import FooForm
 from tests.models import FooModel, BarModel, NonModel
 
@@ -181,7 +181,7 @@ class MultipleModelFieldTest(TestCase):
 
         self.assertEqual(objects, cleaned_data)
 
-    def test_is_requred(self):
+    def test_is_required(self):
         f = MultipleModelField(FooModel)
         with self.assertRaises(ValidationError) as cm:
             f.clean(None)
@@ -189,7 +189,33 @@ class MultipleModelFieldTest(TestCase):
         self.assertEqual(
             'Input is required expected list of models but got None.', cm.exception.message)
 
-    def test_is_not_requred(self):
+    def test_is_not_required(self):
         f = MultipleModelField(FooModel, required=False)
         # should not raise any exception
         f.clean(None)
+
+
+class DictFieldTest(TestCase):
+    def test_is_required(self):
+        dict_field = DictField(required=True)
+
+        with self.assertRaises(ValidationError) as cm:
+            dict_field.clean(None)
+
+        self.assertEqual(
+            'Input is required. Expected dictionary but got None.', cm.exception.message)
+
+    def test_is_not_required(self):
+        dict_field = DictField(required=False)
+
+        # should not raise any exception
+        dict_field.clean(None)
+
+    def test_invalid_type(self):
+        dict_field = DictField(required=True)
+
+        with self.assertRaises(ValidationError) as cm:
+            dict_field.clean('string test')
+
+        self.assertEqual(
+            'Input needs to be of type dict.', cm.exception.message)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 from django.core.exceptions import ValidationError
 
-from service_objects.fields import MultipleFormField, ModelField, MultipleModelField, DictField
+from service_objects.fields import MultipleFormField, ModelField, MultipleModelField, \
+    DictField, ListField
 from tests.forms import FooForm
 from tests.models import FooModel, BarModel, NonModel
 
@@ -219,3 +220,29 @@ class DictFieldTest(TestCase):
 
         self.assertEqual(
             'Input needs to be of type dict.', cm.exception.message)
+
+
+class ListFieldTest(TestCase):
+    def test_is_required(self):
+        list_field = ListField(required=True)
+
+        with self.assertRaises(ValidationError) as cm:
+            list_field.clean(None)
+
+        self.assertEqual(
+            'Input is required. Expected list but got None.', cm.exception.message)
+
+    def test_is_not_required(self):
+        list_field = ListField(required=True)
+
+        # should not raise any exception
+        list_field.clean(None)
+
+    def test_invalid_type(self):
+        list_field = ListField(required=True)
+
+        with self.assertRaises(ValidationError) as cm:
+            list_field.clean('string test')
+
+        self.assertEqual(
+            'Input needs to be of type list.', cm.exception.message)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -203,7 +203,7 @@ class DictFieldTest(TestCase):
             dict_field.clean(None)
 
         self.assertEqual(
-            'Input is required. Expected dictionary but got None.', cm.exception.message)
+            'Input is required. Expected dict but got None.', cm.exception.message)
 
     def test_is_not_required(self):
         dict_field = DictField(required=False)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -233,7 +233,7 @@ class ListFieldTest(TestCase):
             'Input is required. Expected list but got None.', cm.exception.message)
 
     def test_is_not_required(self):
-        list_field = ListField(required=True)
+        list_field = ListField(required=False)
 
         # should not raise any exception
         list_field.clean(None)


### PR DESCRIPTION
There is no way using Django Forms to pass around arbitrary dictionaries. The only other way was to override `__init__` and pass the dictionary "input" as a kwarg which is a hack.  This is a shim to support passing dictionaries to services:

```python
class PDFGenerate(Service):
    context = DictField()

    process(self):
        context = self.cleaned_data['context']

PDFGenerate.execute({
    'context': {'a': 1, 'b': 2}
})
```

PR includes tests.