### PR TITLE
Skip missing python versions when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     py{36,37,38}-django30
 	celery
     docs
+skip_missing_interpreters = true
 
 [testenv]
 deps =


### PR DESCRIPTION
@mixxorz 