### PR TITLE
Update CI version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         django-version: [2.2, 3.1, 3.2, 4.0]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         exclude:
           # Django 4.0 doesn't support Python 3.7
           - python-version: 3.7
-            django-versio: 4.0
+            django-version: 4.0
           # Django 2.2 doesn't support Python 3.10
           - python-version: 3.10
             django-version: 2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.1, 3.2]
+        python-version: [3.7, 3.8, 3.9, 3.10]
+        django-version: [2.2, 3.1, 3.2, 4.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,28 +2,29 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   pull_request:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         django-version: [2.2, 3.1, 3.2, 4.0]
         exclude:
-        # Django 4.0 doesn't support Python 3.7
-        - python-version: 3.7
-          django-versio: 4.0
-        # Django 2.2 doesn't support Python 3.10
-        - python-version: 3.10
-          django-version: 2.2
-        # Django 3.1 doesn't support Python 3.10
-        - python-version: 3.10
-          django-version: 3.1
-
+          # Django 4.0 doesn't support Python 3.7
+          - python-version: 3.7
+            django-versio: 4.0
+          # Django 2.2 doesn't support Python 3.10
+          - python-version: 3.10
+            django-version: 2.2
+          # Django 3.1 doesn't support Python 3.10
+          - python-version: 3.10
+            django-version: 3.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,17 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
         django-version: [2.2, 3.1, 3.2, 4.0]
+        exclude:
+        # Django 4.0 doesn't support Python 3.7
+        - python-version: 3.7
+          django-versio: 4.0
+        # Django 2.2 doesn't support Python 3.10
+        - python-version: 3.10
+          django-version: 2.2
+        # Django 3.1 doesn't support Python 3.10
+        - python-version: 3.10
+          django-version: 3.1
+
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This updates tests to work with Django 4.0, and Python 3.10.